### PR TITLE
feat(getters): add libvirt VM monitoring support

### DIFF
--- a/casedd/config.py
+++ b/casedd/config.py
@@ -300,6 +300,10 @@ class Config:
         ups_interval: UPS polling interval in seconds.
         ups_command: Optional custom UPS command override.
         ups_upsc_target: Target argument for ``upsc`` fallback mode.
+        vms_interval: KVM/libvirt VM polling interval in seconds.
+        vms_passive: Disable local virsh polling and expect external pushes.
+        vms_command: Virsh binary name or absolute path.
+        vms_max_items: Maximum indexed ``vms.<n>`` rows emitted.
         pihole_base_url: Pi-hole API base URL.
         radarr_base_url: Radarr API base URL.
         radarr_api_key: Radarr API key for X-Api-Key auth.
@@ -439,6 +443,10 @@ class Config:
     ups_interval: float = Field(default=5.0)
     ups_command: str | None = Field(default=None)
     ups_upsc_target: str = Field(default="ups@localhost")
+    vms_interval: float = Field(default=10.0)
+    vms_passive: bool = Field(default=False)
+    vms_command: str = Field(default="virsh")
+    vms_max_items: int = Field(default=8, ge=1, le=50)
     radarr_base_url: str = Field(default="")
     radarr_api_key: str | None = Field(default=None, repr=False)
     radarr_interval: float = Field(default=15.0)
@@ -791,6 +799,25 @@ class Config:
             msg = f"ups_interval must be between 1 and 3600 seconds, got {v}"
             raise ValueError(msg)
         return v
+
+    @field_validator("vms_interval")
+    @classmethod
+    def _validate_vms_interval(cls, v: float) -> float:
+        """Ensure VM polling interval is positive and practical."""
+        if not (1.0 <= v <= 3600.0):
+            msg = f"vms_interval must be between 1 and 3600 seconds, got {v}"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("vms_command")
+    @classmethod
+    def _validate_vms_command(cls, value: str) -> str:
+        """Normalize virsh command field and reject blank values."""
+        normalized = value.strip()
+        if not normalized:
+            msg = "vms_command must not be empty"
+            raise ValueError(msg)
+        return normalized
 
     @field_validator("radarr_interval", "sonarr_interval")
     @classmethod
@@ -1270,6 +1297,12 @@ def load_config() -> Config:
         ups_interval=float(str(_get("CASEDD_UPS_INTERVAL", "ups_interval", 5.0))),
         ups_command=str(_get("CASEDD_UPS_COMMAND", "ups_command", "")).strip() or None,
         ups_upsc_target=str(_get("CASEDD_UPS_UPSC_TARGET", "ups_upsc_target", "ups@localhost")),
+        vms_interval=float(str(_get("CASEDD_VMS_INTERVAL", "vms_interval", 10.0))),
+        vms_passive=str(_get("CASEDD_VMS_PASSIVE", "vms_passive", "0"))
+        not in {"0", "false", "False", ""},
+        vms_command=str(_get("CASEDD_VMS_COMMAND", "vms_command", "virsh")).strip()
+        or "virsh",
+        vms_max_items=int(str(_get("CASEDD_VMS_MAX_ITEMS", "vms_max_items", 8))),
         radarr_base_url=str(_get("CASEDD_RADARR_BASE_URL", "radarr_base_url", "")).strip(),
         radarr_api_key=str(_get("CASEDD_RADARR_API_KEY", "radarr_api_key", "")).strip()
         or None,

--- a/casedd/daemon.py
+++ b/casedd/daemon.py
@@ -64,6 +64,7 @@ from casedd.getters.speedtest import SpeedtestGetter
 from casedd.getters.sysinfo import SysinfoGetter
 from casedd.getters.system import SystemGetter
 from casedd.getters.ups import UpsGetter
+from casedd.getters.vms import VmGetter
 from casedd.getters.weather import WeatherGetter
 from casedd.ingestion.unix_socket import UnixSocketIngestion
 from casedd.input_detect import has_local_keyboard_or_mouse
@@ -1152,6 +1153,13 @@ class Daemon:
                 command=self._cfg.ups_command,
                 upsc_target=self._cfg.ups_upsc_target,
             ),
+            VmGetter(
+                self._store,
+                interval=self._cfg.vms_interval,
+                passive=self._cfg.vms_passive,
+                command=self._cfg.vms_command,
+                max_items=self._cfg.vms_max_items,
+            ),
             PiHoleGetter(
                 self._store,
                 base_url=self._cfg.pihole_base_url,
@@ -1334,6 +1342,7 @@ class Daemon:
             ("invokeai.", "InvokeAIGetter"),
             ("ollama.", "OllamaGetter"),
             ("ups.", "UpsGetter"),
+            ("vms.", "VmGetter"),
             ("pihole.", "PiHoleGetter"),
             ("radarr.", "RadarrGetter"),
             ("sonarr.", "SonarrGetter"),

--- a/casedd/getters/__init__.py
+++ b/casedd/getters/__init__.py
@@ -22,5 +22,6 @@ Available getters:
     - :mod:`casedd.getters.speedtest` — Ookla speed test sampling
     - :mod:`casedd.getters.system` — Hostname, uptime, load average
     - :mod:`casedd.getters.ups` — UPS metrics via apcaccess/upsc/custom command
+    - :mod:`casedd.getters.vms` — KVM/libvirt VM telemetry via ``virsh``
     - :mod:`casedd.getters.weather` — NWS/open-meteo weather + alert telemetry
 """

--- a/casedd/getters/vms.py
+++ b/casedd/getters/vms.py
@@ -1,0 +1,446 @@
+"""Virtual machine metrics getter for KVM/libvirt hosts.
+
+Collects VM status and lightweight telemetry via ``virsh``. The getter is
+optional and degrades gracefully when ``virsh``/libvirt is unavailable.
+
+Store keys written:
+    - ``vms.available`` (float) -- 1 when virsh polling is active, else 0
+    - ``vms.mode`` (str) -- ``active``, ``passive``, or ``unavailable``
+    - ``vms.count_total`` (float)
+    - ``vms.count_running`` (float)
+    - ``vms.count_paused`` (float)
+    - ``vms.count_shutoff`` (float)
+    - ``vms.total_allocated_mib`` (float)
+    - ``vms.total_actual_mib`` (float)
+    - ``vms.total_cpu_percent`` (float)
+    - ``vms.rows`` (str) -- newline-delimited ``name|summary`` table rows
+    - ``vms.<index>.*`` (per-VM fields for top N VMs)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import shutil
+import subprocess
+import time
+
+from casedd.data_store import DataStore, StoreValue
+from casedd.getters.base import BaseGetter
+
+_log = logging.getLogger(__name__)
+
+_UNAVAILABLE_ROWS = "libvirt unavailable|Install virsh or use passive push mode"
+_NO_VM_ROWS = "No virtual machines|No domains returned by libvirt"
+
+
+@dataclass(frozen=True)
+class _Domain:
+    """One domain row from ``virsh list --all``."""
+
+    name: str
+    state: str
+
+
+@dataclass(frozen=True)
+class _DomainInfo:
+    """Parsed subset of ``virsh dominfo`` output."""
+
+    state: str
+    os_type: str
+    vcpus: int
+    cpu_time_seconds: float
+    max_memory_mib: float
+    used_memory_mib: float
+
+
+@dataclass
+class _Summary:
+    """Running aggregate counters for one sample pass."""
+
+    running: int = 0
+    paused: int = 0
+    shutoff: int = 0
+    total_allocated_mib: float = 0.0
+    total_actual_mib: float = 0.0
+    total_cpu_percent: float = 0.0
+
+
+@dataclass(frozen=True)
+class _DomainSample:
+    """One sampled VM row with aggregate contribution."""
+
+    row_text: str
+    summary: _Summary
+    state_label: str
+    os_type: str
+    allocated_mib: float
+    actual_mib: float
+    cpu_percent: float
+    uptime_seconds: int
+
+
+class VmGetter(BaseGetter):
+    """Getter for KVM/libvirt VM status and resource telemetry via ``virsh``.
+
+    Args:
+        store: Shared data store instance.
+        interval: Poll interval in seconds.
+        passive: When true, emit only passive-mode status and never run virsh.
+        command: Virsh binary name or absolute path.
+        max_items: Maximum number of indexed per-VM fields to emit.
+    """
+
+    def __init__(
+        self,
+        store: DataStore,
+        interval: float = 10.0,
+        passive: bool = False,
+        command: str = "virsh",
+        max_items: int = 8,
+    ) -> None:
+        """Initialise VM getter settings and detect command availability."""
+        super().__init__(store, interval)
+        self._passive = passive
+        self._command = command
+        self._max_items = max(1, max_items)
+        self._warned_unavailable = False
+        self._cpu_cache: dict[str, tuple[float, float]] = {}
+        self._uptime_started_at: dict[str, float] = {}
+
+        discovered = shutil.which(command)
+        if discovered is not None:
+            self._virsh_path: str | None = discovered
+        elif Path(command).is_file():
+            self._virsh_path = command
+        else:
+            self._virsh_path = None
+
+        self._enabled = (not passive) and (self._virsh_path is not None)
+
+        if self._passive:
+            _log.info("VM getter in passive mode; expecting external pushes under vms.*")
+        elif self._enabled:
+            _log.info("VM getter active via virsh (%s)", self._virsh_path)
+        else:
+            _log.info("VM getter disabled (virsh not found); emitting unavailable fallback")
+
+    async def fetch(self) -> dict[str, StoreValue]:
+        """Collect one VM telemetry sample.
+
+        Returns:
+            Mapping containing ``vms.*`` keys.
+        """
+        return await asyncio.to_thread(self._sample)
+
+    def _sample(self) -> dict[str, StoreValue]:
+        """Blocking VM sample implementation using virsh CLI."""
+        if self._passive:
+            return {
+                "vms.available": 0.0,
+                "vms.mode": "passive",
+                "vms.rows": "Passive mode|Waiting for external vms.* pushes",
+            }
+
+        if not self._enabled or self._virsh_path is None:
+            if not self._warned_unavailable:
+                _log.info(
+                    "VM getter inactive (virsh unavailable); install libvirt tools "
+                    "or set CASEDD_VMS_PASSIVE=1 for push-only mode"
+                )
+                self._warned_unavailable = True
+            return self._unavailable_payload()
+
+        domains = self._list_domains()
+        if domains is None:
+            return self._unavailable_payload()
+        if not domains:
+            return self._empty_payload()
+
+        payload: dict[str, StoreValue] = {
+            "vms.available": 1.0,
+            "vms.mode": "active",
+            "vms.count_total": float(len(domains)),
+        }
+        summary = _Summary()
+        rows: list[str] = []
+        now = time.monotonic()
+
+        for index, domain in enumerate(domains, start=1):
+            domain_sample = self._sample_domain(domain, now)
+            self._write_indexed_domain_fields(payload, domain_sample, domain.name, index)
+            summary.running += domain_sample.summary.running
+            summary.paused += domain_sample.summary.paused
+            summary.shutoff += domain_sample.summary.shutoff
+            summary.total_allocated_mib += domain_sample.summary.total_allocated_mib
+            summary.total_actual_mib += domain_sample.summary.total_actual_mib
+            summary.total_cpu_percent += domain_sample.summary.total_cpu_percent
+            rows.append(f"{domain.name}|{domain_sample.row_text}")
+        payload["vms.count_running"] = float(summary.running)
+        payload["vms.count_paused"] = float(summary.paused)
+        payload["vms.count_shutoff"] = float(summary.shutoff)
+        payload["vms.total_allocated_mib"] = round(summary.total_allocated_mib, 2)
+        payload["vms.total_actual_mib"] = round(summary.total_actual_mib, 2)
+        payload["vms.total_cpu_percent"] = round(summary.total_cpu_percent, 2)
+        payload["vms.rows"] = "\n".join(rows)
+        return payload
+
+    def _sample_domain(
+        self,
+        domain: _Domain,
+        now: float,
+    ) -> _DomainSample:
+        """Collect one domain's metrics and aggregate contribution."""
+        info = self._domain_info(domain)
+        effective_state = info.state if info is not None else domain.state
+        state_label = _state_label(effective_state)
+        os_type = info.os_type if info is not None else "unknown"
+        allocated_mib = info.max_memory_mib if info is not None else 0.0
+        actual_mib = info.used_memory_mib if info is not None else 0.0
+        cpu_percent = self._cpu_percent(domain.name, info, now)
+        uptime_seconds = self._uptime_seconds(domain.name, effective_state, now)
+
+        row_text = (
+            f"{state_label} | CPU {cpu_percent:.1f}% | MEM {actual_mib:.0f}/"
+            f"{allocated_mib:.0f} MiB | UP {format_uptime(uptime_seconds)} | {os_type}"
+        )
+
+        summary = _Summary(
+            total_allocated_mib=allocated_mib,
+            total_actual_mib=actual_mib,
+            total_cpu_percent=cpu_percent,
+        )
+        if state_label == "Running":
+            summary.running = 1
+        elif state_label == "Paused":
+            summary.paused = 1
+        elif state_label == "Shut off":
+            summary.shutoff = 1
+        return _DomainSample(
+            row_text=row_text,
+            summary=summary,
+            state_label=state_label,
+            os_type=os_type,
+            allocated_mib=allocated_mib,
+            actual_mib=actual_mib,
+            cpu_percent=cpu_percent,
+            uptime_seconds=uptime_seconds,
+        )
+
+    def _write_indexed_domain_fields(
+        self,
+        payload: dict[str, StoreValue],
+        sample: _DomainSample,
+        domain_name: str,
+        index: int,
+    ) -> None:
+        """Write per-domain fields for the first ``max_items`` domains."""
+        if index > self._max_items:
+            return
+        base = f"vms.{index}"
+        payload[f"{base}.name"] = domain_name
+        payload[f"{base}.state"] = sample.state_label
+        payload[f"{base}.cpu_percent"] = round(sample.cpu_percent, 2)
+        payload[f"{base}.memory_allocated_mib"] = round(sample.allocated_mib, 2)
+        payload[f"{base}.memory_actual_mib"] = round(sample.actual_mib, 2)
+        payload[f"{base}.uptime_seconds"] = float(sample.uptime_seconds)
+        payload[f"{base}.uptime"] = format_uptime(sample.uptime_seconds)
+        payload[f"{base}.os_type"] = sample.os_type
+
+    def _list_domains(self) -> list[_Domain] | None:
+        """Return all libvirt domains with parsed state labels.
+
+        Returns:
+            Domain list on success, empty list for no domains, or ``None`` on
+            command failure.
+        """
+        output = self._run_command([self._virsh_path or self._command, "list", "--all"])
+        if output is None:
+            return None
+
+        parsed: list[_Domain] = []
+        for raw in output.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("Id"):
+                continue
+            if line and set(line) == {"-"}:
+                continue
+            parts = line.split(maxsplit=2)
+            if len(parts) < 3:
+                continue
+            name = parts[1].strip()
+            state = parts[2].strip().lower()
+            parsed.append(_Domain(name=name, state=state))
+        return parsed
+
+    def _domain_info(self, domain: _Domain) -> _DomainInfo | None:
+        """Fetch detailed telemetry for one VM domain via ``virsh dominfo``."""
+        output = self._run_command(
+            [self._virsh_path or self._command, "dominfo", domain.name],
+        )
+        if output is None:
+            return None
+
+        mapping = _parse_key_value_lines(output)
+        state = mapping.get("state", domain.state).strip().lower()
+        os_type = mapping.get("os type", "unknown").strip().lower() or "unknown"
+        vcpus = _parse_int(mapping.get("cpu(s)", ""), default=1)
+        cpu_time_seconds = _parse_cpu_seconds(mapping.get("cpu time", ""))
+        max_memory_mib = _kib_to_mib(mapping.get("max memory", ""))
+        used_memory_mib = _kib_to_mib(mapping.get("used memory", ""))
+
+        return _DomainInfo(
+            state=state,
+            os_type=os_type,
+            vcpus=max(1, vcpus),
+            cpu_time_seconds=max(0.0, cpu_time_seconds),
+            max_memory_mib=max(0.0, max_memory_mib),
+            used_memory_mib=max(0.0, used_memory_mib),
+        )
+
+    def _cpu_percent(self, domain_name: str, info: _DomainInfo | None, now: float) -> float:
+        """Compute per-domain CPU usage percent from cumulative CPU time."""
+        if info is None or _state_label(info.state) != "Running":
+            return 0.0
+
+        previous = self._cpu_cache.get(domain_name)
+        self._cpu_cache[domain_name] = (info.cpu_time_seconds, now)
+        if previous is None:
+            return 0.0
+
+        prev_cpu_seconds, prev_time = previous
+        elapsed = max(0.001, now - prev_time)
+        cpu_delta = max(0.0, info.cpu_time_seconds - prev_cpu_seconds)
+        cpu_percent = (cpu_delta / elapsed) * 100.0
+        return min(100.0 * float(max(1, info.vcpus)), cpu_percent)
+
+    def _uptime_seconds(self, domain_name: str, state: str, now: float) -> int:
+        """Track coarse VM uptime from state transitions.
+
+        Uses monotonic timestamps and resets when the VM is not running.
+        """
+        if _state_label(state) != "Running":
+            self._cpu_cache.pop(domain_name, None)
+            self._uptime_started_at.pop(domain_name, None)
+            return 0
+
+        started = self._uptime_started_at.get(domain_name)
+        if started is None:
+            self._uptime_started_at[domain_name] = now
+            return 0
+        return max(0, int(now - started))
+
+    @staticmethod
+    def _run_command(args: list[str]) -> str | None:
+        """Run ``virsh`` command safely and return stdout text."""
+        if not args:
+            return None
+        try:
+            proc = subprocess.run(  # noqa: S603 -- fixed argv, shell disabled
+                args,
+                capture_output=True,
+                text=True,
+                timeout=8,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+            _log.debug("VM getter command failed: %s", args, exc_info=True)
+            return None
+        text = proc.stdout.strip()
+        return text if text else ""
+
+    @staticmethod
+    def _unavailable_payload() -> dict[str, StoreValue]:
+        """Payload used when virsh/libvirt are unavailable."""
+        return {
+            "vms.available": 0.0,
+            "vms.mode": "unavailable",
+            "vms.count_total": 0.0,
+            "vms.count_running": 0.0,
+            "vms.count_paused": 0.0,
+            "vms.count_shutoff": 0.0,
+            "vms.total_allocated_mib": 0.0,
+            "vms.total_actual_mib": 0.0,
+            "vms.total_cpu_percent": 0.0,
+            "vms.rows": _UNAVAILABLE_ROWS,
+        }
+
+    @staticmethod
+    def _empty_payload() -> dict[str, StoreValue]:
+        """Payload used when libvirt is available but has no domains."""
+        return {
+            "vms.available": 1.0,
+            "vms.mode": "active",
+            "vms.count_total": 0.0,
+            "vms.count_running": 0.0,
+            "vms.count_paused": 0.0,
+            "vms.count_shutoff": 0.0,
+            "vms.total_allocated_mib": 0.0,
+            "vms.total_actual_mib": 0.0,
+            "vms.total_cpu_percent": 0.0,
+            "vms.rows": _NO_VM_ROWS,
+        }
+
+
+def _parse_key_value_lines(output: str) -> dict[str, str]:
+    """Parse ``Key: Value`` command output to lowercase key mapping."""
+    result: dict[str, str] = {}
+    for raw_line in output.splitlines():
+        if ":" not in raw_line:
+            continue
+        key, value = raw_line.split(":", maxsplit=1)
+        result[key.strip().lower()] = value.strip()
+    return result
+
+
+def _parse_cpu_seconds(raw: str) -> float:
+    """Parse dominfo CPU time value (e.g. ``123.4s``) into seconds."""
+    cleaned = raw.strip().lower().removesuffix("s").strip()
+    try:
+        return float(cleaned)
+    except ValueError:
+        return 0.0
+
+
+def _parse_int(raw: str, default: int) -> int:
+    """Extract first integer token from a free-form value string."""
+    token = raw.strip().split(maxsplit=1)[0] if raw.strip() else ""
+    try:
+        return int(token)
+    except ValueError:
+        return default
+
+
+def _kib_to_mib(raw: str) -> float:
+    """Parse libvirt KiB memory field into MiB."""
+    token = raw.strip().split(maxsplit=1)[0] if raw.strip() else ""
+    try:
+        return float(token) / 1024.0
+    except ValueError:
+        return 0.0
+
+
+def _state_label(state: str) -> str:
+    """Map libvirt state text into compact dashboard labels."""
+    normalized = state.strip().lower()
+    if normalized.startswith("running"):
+        return "Running"
+    if normalized.startswith("paused"):
+        return "Paused"
+    if normalized in {"shut off", "shutoff", "shutdown"}:
+        return "Shut off"
+    return normalized.title() if normalized else "Unknown"
+
+
+def format_uptime(seconds: int) -> str:
+    """Render uptime seconds as compact ``Xd HH:MM:SS`` text."""
+    if seconds <= 0:
+        return "00:00:00"
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, secs = divmod(rem, 60)
+    if days > 0:
+        return f"{days}d {hours:02}:{minutes:02}:{secs:02}"
+    return f"{hours:02}:{minutes:02}:{secs:02}"

--- a/templates/kvm_vms.casedd
+++ b/templates/kvm_vms.casedd
@@ -1,0 +1,64 @@
+# kvm_vms.casedd — KVM/libvirt virtual machine dashboard
+
+name: kvm_vms
+description: Running/paused/shutoff VM summary with per-VM status table.
+aspect_ratio: "5:3"
+layout_mode: fit
+background: "#0b1118"
+refresh_rate: 5.0
+
+grid:
+  template_areas: |
+    "summary summary summary"
+    "running paused shutoff"
+    "table table table"
+  columns: "1fr 1fr 1fr"
+  rows: "0.22fr 0.22fr 0.56fr"
+
+widgets:
+  summary:
+    type: value
+    source: vms.count_total
+    label: "Total VMs"
+    color: "#8ac6ff"
+    background: "#101822"
+    font_size: auto
+    padding: 8
+
+  running:
+    type: value
+    source: vms.count_running
+    label: "Running"
+    color: "#74d680"
+    background: "#0f1a24"
+    font_size: auto
+    padding: 8
+
+  paused:
+    type: value
+    source: vms.count_paused
+    label: "Paused"
+    color: "#ffd166"
+    background: "#0f1a24"
+    font_size: auto
+    padding: 8
+
+  shutoff:
+    type: value
+    source: vms.count_shutoff
+    label: "Shut off"
+    color: "#ff8c69"
+    background: "#0f1a24"
+    font_size: auto
+    padding: 8
+
+  table:
+    type: table
+    source: vms.rows
+    label: "Virtual Machines"
+    color: "#dfe7ef"
+    background: "#101822"
+    font_size: auto
+    table_fit_text: true
+    max_items: 8
+    padding: [8, 10]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -254,6 +254,23 @@ def test_os_updates_env_settings_parse(monkeypatch: object, tmp_path: Path) -> N
         assert cfg.os_updates_manager == "apt"
 
 
+def test_vms_env_settings_parse(monkeypatch: object, tmp_path: Path) -> None:
+        """VM getter env vars should map into typed config fields."""
+        monkeypatch_obj = monkeypatch
+        monkeypatch_obj.setenv("CASEDD_CONFIG", str(tmp_path / "missing.yaml"))
+        monkeypatch_obj.setenv("CASEDD_VMS_INTERVAL", "15")
+        monkeypatch_obj.setenv("CASEDD_VMS_PASSIVE", "1")
+        monkeypatch_obj.setenv("CASEDD_VMS_COMMAND", "/usr/bin/virsh")
+        monkeypatch_obj.setenv("CASEDD_VMS_MAX_ITEMS", "12")
+
+        cfg = load_config()
+
+        assert cfg.vms_interval == 15.0
+        assert cfg.vms_passive is True
+        assert cfg.vms_command == "/usr/bin/virsh"
+        assert cfg.vms_max_items == 12
+
+
 def test_servarr_env_settings_parse(monkeypatch: object, tmp_path: Path) -> None:
         """Radarr/Sonarr env vars should map into typed config fields."""
         monkeypatch_obj = monkeypatch

--- a/tests/test_daemon_getter_planning.py
+++ b/tests/test_daemon_getter_planning.py
@@ -101,3 +101,8 @@ def test_getter_name_for_source_includes_invokeai() -> None:
 def test_getter_name_for_source_includes_os_updates() -> None:
     """os_updates namespace should resolve to OsUpdatesGetter."""
     assert Daemon._getter_name_for_source("os_updates.has_updates") == "OsUpdatesGetter"
+
+
+def test_getter_name_for_source_includes_vms() -> None:
+    """vms namespace should resolve to VmGetter."""
+    assert Daemon._getter_name_for_source("vms.count_running") == "VmGetter"

--- a/tests/test_getters_vms.py
+++ b/tests/test_getters_vms.py
@@ -1,0 +1,93 @@
+"""Tests for KVM/libvirt VM getter parsing and fallback behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from casedd.data_store import DataStore
+from casedd.getters.vms import VmGetter, format_uptime
+
+
+def test_vm_getter_builds_vm_rows_and_summary() -> None:
+    """Getter should emit summary + per-VM fields from virsh output."""
+    list_stdout = (
+        " Id   Name          State\n"
+        "-----------------------------\n"
+        " 1    media-vm      running\n"
+        " -    build-vm      shut off\n"
+    )
+    dominfo_running = (
+        "Id:             1\n"
+        "Name:           media-vm\n"
+        "OS Type:        hvm\n"
+        "State:          running\n"
+        "CPU(s):         2\n"
+        "CPU time:       12.5s\n"
+        "Max memory:     4194304 KiB\n"
+        "Used memory:    1048576 KiB\n"
+    )
+    dominfo_stopped = (
+        "Id:             -\n"
+        "Name:           build-vm\n"
+        "OS Type:        hvm\n"
+        "State:          shut off\n"
+        "CPU(s):         4\n"
+        "CPU time:       0.0s\n"
+        "Max memory:     8388608 KiB\n"
+        "Used memory:    0 KiB\n"
+    )
+
+    def _run_side_effect(args: list[str], **_: object) -> object:
+        class _CompletedProcess:
+            def __init__(self, stdout: str) -> None:
+                self.stdout = stdout
+
+        if args[1:3] == ["list", "--all"]:
+            return _CompletedProcess(list_stdout)
+        if args[1:3] == ["dominfo", "media-vm"]:
+            return _CompletedProcess(dominfo_running)
+        return _CompletedProcess(dominfo_stopped)
+
+    with (
+        patch("casedd.getters.vms.shutil.which", return_value="/usr/bin/virsh"),
+        patch("casedd.getters.vms.subprocess.run", side_effect=_run_side_effect),
+    ):
+        getter = VmGetter(DataStore(), max_items=3)
+        payload = getter._sample()
+
+    assert payload["vms.available"] == 1.0
+    assert payload["vms.count_total"] == 2.0
+    assert payload["vms.count_running"] == 1.0
+    assert payload["vms.count_shutoff"] == 1.0
+    assert payload["vms.1.name"] == "media-vm"
+    assert payload["vms.1.state"] == "Running"
+    assert payload["vms.2.name"] == "build-vm"
+    assert "media-vm|Running" in str(payload["vms.rows"])
+
+
+def test_vm_getter_unavailable_when_virsh_missing() -> None:
+    """Getter should emit unavailable fallback when virsh is missing."""
+    with patch("casedd.getters.vms.shutil.which", return_value=None):
+        getter = VmGetter(DataStore())
+        payload = getter._sample()
+
+    assert payload["vms.mode"] == "unavailable"
+    assert payload["vms.available"] == 0.0
+    assert payload["vms.rows"]
+
+
+def test_vm_getter_passive_mode() -> None:
+    """Passive mode should avoid virsh polling and publish passive status."""
+    with patch("casedd.getters.vms.shutil.which", return_value="/usr/bin/virsh"):
+        getter = VmGetter(DataStore(), passive=True)
+        payload = getter._sample()
+
+    assert payload["vms.mode"] == "passive"
+    assert payload["vms.available"] == 0.0
+
+
+def test_format_uptime_compact_text() -> None:
+    """Uptime formatter should emit day prefix for long durations."""
+    assert format_uptime(0) == "00:00:00"
+    assert format_uptime(3661) == "01:01:01"
+    assert format_uptime(90061) == "1d 01:01:01"


### PR DESCRIPTION
## Summary
- add a new VmGetter for KVM/libvirt telemetry via virsh with graceful fallback when unavailable
- add passive mode support for external vms.* push workflows
- wire vms.* namespace into getter planning and daemon getter construction
- add kvm_vms example template
- add unit tests for VM getter parsing/fallback/passive behavior and config/getter mapping coverage

## Validation
- ruff check .
- mypy --strict casedd/
- pytest -q

All checks pass on this branch.

Closes #48
